### PR TITLE
Fix issue MCCTeam#2111

### DIFF
--- a/ConsoleInteractive/ConsoleInteractive/ConsoleWriter.cs
+++ b/ConsoleInteractive/ConsoleInteractive/ConsoleWriter.cs
@@ -36,6 +36,10 @@ namespace ConsoleInteractive {
 
     internal static class InternalWriter {
         private static void Write(string value) {
+            int linesAdded = 0;
+            foreach (string line in value.Split('\n'))
+                linesAdded += (line.Length / InternalContext.CursorLeftPosLimit) + 1;
+
             lock (InternalContext.WriteLock) {
                 
                 // If the buffer is initialized, then we should get the current cursor position
@@ -54,7 +58,6 @@ namespace ConsoleInteractive {
                     ConsoleBuffer.ClearCurrentLine();
                 
                 Console.WriteLine(value);
-                int linesAdded = (value.Length / InternalContext.CursorLeftPosLimit) + 1;
                 
                 // Determine if we need to use the previous top position.
                 // i.e. vertically constrained.


### PR DESCRIPTION
fix #10 

This bug is caused by a combination of two problems: one is that acceptnewlines=false when WriteLineFormatted is called, and the other is that '\n' is not taken into account when counting the number of occupied lines.