### PR TITLE
Fix the bug of command history

### DIFF
--- a/ConsoleInteractive/ConsoleInteractive/ConsoleReader.cs
+++ b/ConsoleInteractive/ConsoleInteractive/ConsoleReader.cs
@@ -172,13 +172,14 @@ namespace ConsoleInteractive {
                             var backreadCopied = ConsoleBuffer.isCurrentBufferCopied;
                             var backreadString = ConsoleBuffer.UserInputBufferCopy;
                             ConsoleBuffer.SetBufferContent(backread);
+                            ConsoleBuffer.MoveToEndBufferPosition();
 
                             // SetBufferContent clears the backread, so we need to pass it again
                             if (backreadCopied) {
                                 ConsoleBuffer.isCurrentBufferCopied = backreadCopied;
                                 ConsoleBuffer.UserInputBufferCopy = backreadString;
                                 
-                                Trace.Assert(ConsoleBuffer.isCurrentBufferCopied && ConsoleBuffer.UserInputBufferCopy.Length != 0);
+                                Trace.Assert(ConsoleBuffer.isCurrentBufferCopied);
                             }
                         }
 
@@ -192,14 +193,15 @@ namespace ConsoleInteractive {
                             var backreadCopied = ConsoleBuffer.isCurrentBufferCopied;
                             var backreadString = ConsoleBuffer.UserInputBufferCopy;
                             ConsoleBuffer.SetBufferContent(backread);
-                            
+                            ConsoleBuffer.MoveToEndBufferPosition();
+
 
                             // SetBufferContent clears the backread, so we need to pass it again
                             if (backreadCopied) {
                                 ConsoleBuffer.isCurrentBufferCopied = backreadCopied;
                                 ConsoleBuffer.UserInputBufferCopy = backreadString;
                                 
-                                Trace.Assert(ConsoleBuffer.isCurrentBufferCopied && ConsoleBuffer.UserInputBufferCopy.Length != 0);
+                                Trace.Assert(ConsoleBuffer.isCurrentBufferCopied);
                             }
                         }
                         


### PR DESCRIPTION
fix #13 

Make the behavior of the command history more consistent with minecraft.
* No empty or space-only messages will be recorded.
* Consecutive messages with the same content are recorded as one.
* "UserInputBufferCopy" will be updated even if the user has no input.
* Cursor moves to the end after switching.
* Reset "BufferBackreadPos" after pressing Enter.

![5](https://user-images.githubusercontent.com/26017411/189489429-f7e2141c-5596-47a7-9a2b-d35117ae06f1.gif)
