### PR TITLE
Implement a simulated pop-up window to display completion suggestions & Bug fix

### DIFF
--- a/ConsoleInteractive/ConsoleInteractive/ConsoleBuffer.cs
+++ b/ConsoleInteractive/ConsoleInteractive/ConsoleBuffer.cs
@@ -339,7 +339,7 @@ namespace ConsoleInteractive {
                 BufferPosition = UserInputBuffer.Length;
         }
 
-        internal static void RedrawInputArea(bool RedrawAll = false, bool WidthChange = false) {
+        internal static void RedrawInputArea(bool RedrawAll = false) {
             if (InternalContext.SuppressInput)
                 return;
 

--- a/ConsoleInteractive/ConsoleInteractive/ConsoleBuffer.cs
+++ b/ConsoleInteractive/ConsoleInteractive/ConsoleBuffer.cs
@@ -108,6 +108,8 @@ namespace ConsoleInteractive {
         /// Initializes the ConsoleBuffer. Required to be called before using the ConsoleBuffer.
         /// </summary>
         internal static void Init() {
+            BufferPosition = 0;
+            lastInputArea = string.Empty;
             RedrawInputArea();
             InternalContext.BufferInitialized = true;
         }

--- a/ConsoleInteractive/ConsoleInteractive/ConsoleBuffer.cs
+++ b/ConsoleInteractive/ConsoleInteractive/ConsoleBuffer.cs
@@ -353,7 +353,7 @@ namespace ConsoleInteractive {
             if (InternalContext.SuppressInput)
                 return;
 
-            if (Console.IsOutputRedirected)
+            if (Console.IsOutputRedirected || !ConsoleReader.DisplayUesrInput)
                 return;
 
             StringBuilder sb = new(Console.BufferWidth);
@@ -370,8 +370,8 @@ namespace ConsoleInteractive {
                     if (BufferPosition != UserInputBuffer.Length)
                         BufferOutputAnchor += (UserInputBuffer[BufferOutputAnchor + 1] == '\0') ? 2 : 1;
                 } else if (BufferPosition == BufferOutputAnchor + bufMaxLen - 1
-                        && UserInputBuffer.Length > BufferPosition + 1
-                        && UserInputBuffer[BufferPosition + 1] == '\0') {
+                          && UserInputBuffer.Length > BufferPosition + 1
+                          && UserInputBuffer[BufferPosition + 1] == '\0') {
                     BufferOutputAnchor += 2;
                 } else if (UserInputBuffer.Length > 0 && UserInputBuffer[BufferOutputAnchor] == '\0') {
                     ++BufferOutputAnchor;

--- a/ConsoleInteractive/ConsoleInteractive/ConsoleBuffer.cs
+++ b/ConsoleInteractive/ConsoleInteractive/ConsoleBuffer.cs
@@ -339,10 +339,10 @@ namespace ConsoleInteractive {
                     Interlocked.Add(ref BufferOutputAnchor, backLen);
                     InternalContext.IncrementLeftPos(moveCnt - backLen);
                 }
+                RedrawInput();
             } else {
                 InternalContext.IncrementLeftPos(moveCnt);
             }
-            RedrawInput();
         }
 
         /// <summary>
@@ -364,10 +364,10 @@ namespace ConsoleInteractive {
                     InternalContext.DecrementLeftPos(moveCnt - BufferOutputAnchor);
                     BufferOutputAnchor = 0;
                 }
+                RedrawInput();
             } else {
                 InternalContext.DecrementLeftPos(moveCnt);
             }
-            RedrawInput();
         }
 
         /// <summary>

--- a/ConsoleInteractive/ConsoleInteractive/ConsoleBuffer.cs
+++ b/ConsoleInteractive/ConsoleInteractive/ConsoleBuffer.cs
@@ -339,8 +339,21 @@ namespace ConsoleInteractive {
                 BufferPosition = UserInputBuffer.Length;
         }
 
+        internal static void PrintUserInput() {
+            string input;
+            lock (InternalContext.UserInputBufferLock)
+                input = "Input: "
+                        + UserInputBuffer.ToString(0, BufferPosition).Replace("\0", string.Empty)
+                        + "|<--"
+                        + UserInputBuffer.ToString(BufferPosition, UserInputBuffer.Length - BufferPosition).Replace("\0", string.Empty);
+            ConsoleWriter.WriteLine(input);
+        }
+
         internal static void RedrawInputArea(bool RedrawAll = false) {
             if (InternalContext.SuppressInput)
+                return;
+
+            if (Console.IsOutputRedirected)
                 return;
 
             StringBuilder sb = new(Console.BufferWidth);

--- a/ConsoleInteractive/ConsoleInteractive/ConsoleBuffer.cs
+++ b/ConsoleInteractive/ConsoleInteractive/ConsoleBuffer.cs
@@ -61,7 +61,7 @@ namespace ConsoleInteractive {
      * - Attempting to decrement further than the Console Width does nothing.
      *
      */
-    internal static class ConsoleBuffer {
+    public static class ConsoleBuffer {
         internal static StringBuilder UserInputBuffer = new();
 
         /// <summary>
@@ -423,10 +423,17 @@ namespace ConsoleInteractive {
 
 
         private static volatile int BufferBackreadPos = 0;
-        private const int BackreadBufferLimit = 32;
+        private static int BackreadBufferLimit = 32;
         internal static List<string> BackreadBuffer = new(BackreadBufferLimit + 1);
         internal static string UserInputBufferCopy = string.Empty;
         internal static bool isCurrentBufferCopied;
+
+        public static int SetBackreadBufferLimit(int limit) {
+            if (limit < 1)
+                limit = 1;
+            BackreadBufferLimit = limit;
+            return limit;
+        }
 
         public static void ClearBackreadBuffer() {
             lock (InternalContext.BackreadBufferLock) {
@@ -492,8 +499,9 @@ namespace ConsoleInteractive {
             lock (InternalContext.BackreadBufferLock) {
                 if (!string.IsNullOrWhiteSpace(message) && (BackreadBuffer.Count == 0 || message != BackreadBuffer[^1])) {
                     BackreadBuffer.Add(message);
-                    if (BackreadBuffer.Count > BackreadBufferLimit)
-                        BackreadBuffer.RemoveAt(0);
+                    int removeCount = BackreadBuffer.Count - BackreadBufferLimit;
+                    if (removeCount > 0)
+                        BackreadBuffer.RemoveRange(0, removeCount);
                 }
                 Interlocked.Exchange(ref BufferBackreadPos, BackreadBuffer.Count);
             }

--- a/ConsoleInteractive/ConsoleInteractive/ConsoleInteractive.csproj
+++ b/ConsoleInteractive/ConsoleInteractive/ConsoleInteractive.csproj
@@ -9,7 +9,7 @@
         <PackageId>ConsoleInteractivePrompt</PackageId>
         <PackageLicenseUrl>https://github.com/breadbyte/ConsoleInteractive/blob/main/LICENSE</PackageLicenseUrl>
         <LangVersion>default</LangVersion>
-        <TargetFrameworks>NET6.0</TargetFrameworks>
+        <TargetFrameworks>NET7.0;NET6.0</TargetFrameworks>
         <OutputType>Library</OutputType>
         <PublishSingleFile>false</PublishSingleFile>
     </PropertyGroup>

--- a/ConsoleInteractive/ConsoleInteractive/ConsoleInteractive.csproj
+++ b/ConsoleInteractive/ConsoleInteractive/ConsoleInteractive.csproj
@@ -15,7 +15,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="PInvoke.Kernel32" Version="0.7.104" />
+      <PackageReference Include="PInvoke.Kernel32" Version="0.7.124" />
+      <PackageReference Include="Wcwidth" Version="1.0.0" />
     </ItemGroup>
 
 </Project>

--- a/ConsoleInteractive/ConsoleInteractive/ConsoleInteractive.csproj
+++ b/ConsoleInteractive/ConsoleInteractive/ConsoleInteractive.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <Title>ConsoleInteractive</Title>
@@ -9,7 +9,7 @@
         <PackageId>ConsoleInteractivePrompt</PackageId>
         <PackageLicenseUrl>https://github.com/breadbyte/ConsoleInteractive/blob/main/LICENSE</PackageLicenseUrl>
         <LangVersion>default</LangVersion>
-        <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+        <TargetFrameworks>NET6.0</TargetFrameworks>
         <OutputType>Library</OutputType>
         <PublishSingleFile>false</PublishSingleFile>
     </PropertyGroup>

--- a/ConsoleInteractive/ConsoleInteractive/ConsoleInteractive.csproj
+++ b/ConsoleInteractive/ConsoleInteractive/ConsoleInteractive.csproj
@@ -9,7 +9,7 @@
         <PackageId>ConsoleInteractivePrompt</PackageId>
         <PackageLicenseUrl>https://github.com/breadbyte/ConsoleInteractive/blob/main/LICENSE</PackageLicenseUrl>
         <LangVersion>default</LangVersion>
-        <TargetFrameworks>NET7.0;NET6.0</TargetFrameworks>
+        <TargetFrameworks>NET7.0</TargetFrameworks>
         <OutputType>Library</OutputType>
         <PublishSingleFile>false</PublishSingleFile>
     </PropertyGroup>

--- a/ConsoleInteractive/ConsoleInteractive/ConsoleReader.cs
+++ b/ConsoleInteractive/ConsoleInteractive/ConsoleReader.cs
@@ -114,7 +114,6 @@ namespace ConsoleInteractive {
                     int charInt;
                     while ((charInt = Console.In.Read()) != -1) {
                         char c = (char)charInt;
-                        ConsoleWriter.WriteLine("char = " + charInt);
                         if (c == '\n') {
                             OnEnter();
                             if (token.IsCancellationRequested) return;

--- a/ConsoleInteractive/ConsoleInteractive/ConsoleReader.cs
+++ b/ConsoleInteractive/ConsoleInteractive/ConsoleReader.cs
@@ -110,18 +110,7 @@ namespace ConsoleInteractive {
                     Thread.Sleep(8);
                 }
 
-                bool needCheckBufUpdate = false, widthChange = false;
-
-                // TODO: Guard against window resize
-                // this is not entirely foolproof
-                // need to interact internally with InternalContext
-                // and mess with the ConsoleBuffer to make this work
-                int newCursorLeftLimit = Console.BufferWidth;
-                int oldCursorLeftLimit = InternalContext.CursorLeftPosLimit;
-                InternalContext.CursorLeftPosLimit = newCursorLeftLimit;
-                if (oldCursorLeftLimit != newCursorLeftLimit)
-                    widthChange = true;
-
+                bool needCheckBufUpdate = false;
                 while (Console.KeyAvailable) {
                     ConsoleKeyInfo k = Console.ReadKey(true);
 
@@ -245,11 +234,10 @@ namespace ConsoleInteractive {
                     }
                 }
 
-                if (widthChange || needCheckBufUpdate)
-                    ConsoleBuffer.RedrawInputArea(WidthChange: widthChange);
-
-                if (needCheckBufUpdate)
+                if (needCheckBufUpdate) {
+                    ConsoleBuffer.RedrawInputArea();
                     CheckInputBufferUpdate();
+                }
             }
             InternalContext.BufferInitialized = false;
         }

--- a/ConsoleInteractive/ConsoleInteractive/ConsoleReader.cs
+++ b/ConsoleInteractive/ConsoleInteractive/ConsoleReader.cs
@@ -72,12 +72,14 @@ namespace ConsoleInteractive {
                 }
 
                 _cancellationTokenSource?.Cancel();
+
+                try { _readerThread!.Join(); }
+                catch (Exception) { }
+
                 InternalContext.BufferInitialized = false;
                 ConsoleBuffer.ClearBackreadBuffer();
                 ConsoleBuffer.FlushBuffer();
                 ConsoleBuffer.ClearVisibleUserInput();
-
-                _readerThread!.Join();
             }
         }
 

--- a/ConsoleInteractive/ConsoleInteractive/ConsoleReader.cs
+++ b/ConsoleInteractive/ConsoleInteractive/ConsoleReader.cs
@@ -4,6 +4,8 @@ using System.Threading;
 
 namespace ConsoleInteractive {
     public static class ConsoleReader {
+        public static bool DisplayUesrInput { get; set; } = true;
+
         /// <summary>
         /// Invoked when a message is received.
         /// </summary>

--- a/ConsoleInteractive/ConsoleInteractive/ConsoleReader.cs
+++ b/ConsoleInteractive/ConsoleInteractive/ConsoleReader.cs
@@ -109,7 +109,7 @@ namespace ConsoleInteractive {
 
                 while (Console.KeyAvailable == false) {
                     if (token.IsCancellationRequested) return;
-                    Thread.Sleep(8);
+                    Thread.Sleep(16);
                     continue;
                 }
 

--- a/ConsoleInteractive/ConsoleInteractive/ConsoleReader.cs
+++ b/ConsoleInteractive/ConsoleInteractive/ConsoleReader.cs
@@ -84,6 +84,7 @@ namespace ConsoleInteractive {
             var bufferString = string.Empty;
 
             BeginReadThread(new CancellationTokenSource());
+            ConsoleBuffer.Init();
             MessageReceived += (sender, s) => {
                 bufferString = s;
                 autoEvent.Set();

--- a/ConsoleInteractive/ConsoleInteractive/ConsoleReader.cs
+++ b/ConsoleInteractive/ConsoleInteractive/ConsoleReader.cs
@@ -28,7 +28,7 @@ namespace ConsoleInteractive {
             ConsoleBuffer.FlushBuffer();
         }
 
-        private static void CheckInputBufferUpdate() {
+        internal static void CheckInputBufferUpdate() {
             ConsoleSuggestion.OnInputUpdate();
             Buffer InputBuffer = GetBufferContent();
             if (InputBuffer != LastInputBuffer) {

--- a/ConsoleInteractive/ConsoleInteractive/ConsoleReader.cs
+++ b/ConsoleInteractive/ConsoleInteractive/ConsoleReader.cs
@@ -103,9 +103,6 @@ namespace ConsoleInteractive {
             ConsoleBuffer.Init();
 
             while (!token.IsCancellationRequested) {
-                if (token.IsCancellationRequested) return;
-
-
                 if (Console.IsInputRedirected) {
                     while (Console.In.Peek() == -1) {
                         if (token.IsCancellationRequested) return;
@@ -262,7 +259,6 @@ namespace ConsoleInteractive {
                         CheckInputBufferUpdate();
                     }
                 }
-
             }
             InternalContext.BufferInitialized = false;
         }

--- a/ConsoleInteractive/ConsoleInteractive/ConsoleSuggestion.cs
+++ b/ConsoleInteractive/ConsoleInteractive/ConsoleSuggestion.cs
@@ -321,7 +321,7 @@ namespace ConsoleInteractive {
             }
 
             private static BgMessageBuffer[] GetBgMessageBuffer(RecentMessageHandler.RecentMessage? msg, int start, int length) {
-                if (msg == null)
+                if (msg == null || msg.Message.Length == 0)
                     return new BgMessageBuffer[1] { new BgMessageBuffer(start, start + length, length) };
 
                 int charIndex = 0;
@@ -421,7 +421,6 @@ namespace ConsoleInteractive {
             }
 
             private static int GetLowerBoundColorCode(Tuple<int, string>[] ColorCodes, int charStart) {
-                --charStart;
                 int left = 0, right = ColorCodes.Length - 1;
                 while (left < right) {
                     int mid = (left + right) / 2;
@@ -440,7 +439,7 @@ namespace ConsoleInteractive {
 
                 internal static void AddMessage(string message) {
                     string[] lines = message.Split('\n');
-                    int startIdx = MaxSuggestions * (lines.Length / MaxSuggestions);
+                    int startIdx = Math.Max(0, lines.Length - MaxSuggestions);
                     for (int i = startIdx; i < lines.Length; i++) {
                         Index = Count < MaxSuggestions ? Count++ : (Index + 1) % MaxSuggestions;
                         Messages[Index] = new(lines[i]);

--- a/ConsoleInteractive/ConsoleInteractive/ConsoleSuggestion.cs
+++ b/ConsoleInteractive/ConsoleInteractive/ConsoleSuggestion.cs
@@ -150,8 +150,10 @@ namespace ConsoleInteractive {
         }
 
         public static void UpdateSuggestions(Suggestion[] Suggestions, Tuple<int, int> range) {
-            if (Console.IsOutputRedirected)
+            if (Console.IsOutputRedirected) {
+                ClearSuggestions();
                 return;
+            }
 
             int maxLength = 0;
             foreach (Suggestion sug in Suggestions)
@@ -160,6 +162,11 @@ namespace ConsoleInteractive {
                         (sug.TooltipWidth == 0 ? 0 : (sug.TooltipWidth + 1))));
 
             if (Suggestions.Length == 0 || maxLength == 0) {
+                ClearSuggestions();
+                return;
+            }
+
+            if (Console.BufferWidth < maxLength) {
                 ClearSuggestions();
                 return;
             }
@@ -468,8 +475,10 @@ namespace ConsoleInteractive {
                 Console.SetCursorPosition(buf.CursorStart, cursorTop);
                 if (EnableColor)
                     Console.Write(sb.ToString());
-                else
+                else if (ConsoleWriter.EnableColor)
                     Console.Write(ResetColorCode + InternalWriter.ColorCodeRegex.Replace(sb.ToString(), string.Empty));
+                else
+                    Console.Write(InternalWriter.ColorCodeRegex.Replace(sb.ToString(), string.Empty));
             }
 
             private static void ClearSingleSuggestionPopup(BgMessageBuffer buf, int cursorTop) {
@@ -482,7 +491,10 @@ namespace ConsoleInteractive {
                 sb.Append(' ', buf.AfterTextSpace);
 
                 Console.SetCursorPosition(buf.CursorStart, cursorTop);
-                Console.Write(sb.ToString());
+                if (ConsoleWriter.EnableColor)
+                    Console.Write(sb.ToString());
+                else
+                    Console.Write(InternalWriter.ColorCodeRegex.Replace(sb.ToString(), string.Empty));
             }
 
             private static BgMessageBuffer[] GetBgMessageBuffer(RecentMessageHandler.RecentMessage? msg, int start, int length, int bufWidth) {

--- a/ConsoleInteractive/ConsoleInteractive/ConsoleSuggestion.cs
+++ b/ConsoleInteractive/ConsoleInteractive/ConsoleSuggestion.cs
@@ -20,9 +20,12 @@ namespace ConsoleInteractive {
         private static Suggestion[] Suggestions = Array.Empty<Suggestion>();
 
 
-        internal static void OnWriteLine(string message, int linesAdded) {
+        internal static void BeforeWriteLine(string message, int linesAdded) {
             if (InUse) DrawHelper.ClearSuggestionPopup(linesAdded);
             DrawHelper.AddMessage(message);
+        }
+
+        internal static void AfterWriteLine() {
             if (InUse) DrawHelper.DrawSuggestionPopup();
         }
 
@@ -126,8 +129,7 @@ namespace ConsoleInteractive {
             ClearSuggestions();
         }
 
-        private static bool CheckIfNeedClear(Suggestion[] Suggestions, Tuple<int, int> range, int maxLength)
-        {
+        private static bool CheckIfNeedClear(Suggestion[] Suggestions, Tuple<int, int> range, int maxLength) {
             if (Suggestions.Length < MaxSuggestionLength && ConsoleSuggestion.Suggestions.Length > MaxSuggestionLength)
                 return true;
             if (ConsoleSuggestion.Suggestions.Length < MaxSuggestionLength && ConsoleSuggestion.Suggestions.Length > Suggestions.Length)
@@ -217,9 +219,9 @@ namespace ConsoleInteractive {
             internal static void DrawSuggestionPopup(bool refreshMsgBuf = true) {
                 BgMessageBuffer[] messageBuffers = Array.Empty<BgMessageBuffer>();
                 int curBufIdx = -1, nextMessageIdx = 0;
-                LastDrawStartPos = GetDrawStartPos();
                 InternalContext.SetCursorVisible(false);
                 int top = InternalContext.CurrentCursorTopPos, left = InternalContext.CurrentCursorLeftPos;
+                LastDrawStartPos = GetDrawStartPos();
                 for (int i = ViewBottom - 1; i >= ViewTop; --i) {
                     if (refreshMsgBuf) {
                         if (curBufIdx < 0) {
@@ -244,7 +246,7 @@ namespace ConsoleInteractive {
                 Console.Write(ResetColorCode);
                 for (int i = 0; i < DisplaySuggestionsCnt; ++i) {
                     if (linesAdded > 0 && i >= linesAdded && drawStartPos == LastDrawStartPos) break;
-                    ClearSingleSuggestionPopup(BgBuffer[i], cursorTop: top - (DisplaySuggestionsCnt - i) - linesAdded);
+                    ClearSingleSuggestionPopup(BgBuffer[i], cursorTop: top - (DisplaySuggestionsCnt - i));
                 }
                 Console.SetCursorPosition(left, top);
                 InternalContext.SetCursorVisible(true);
@@ -278,6 +280,7 @@ namespace ConsoleInteractive {
             }
 
             private static void DrawSingleSuggestionPopup(int index, BgMessageBuffer buf, int cursorTop) {
+                if (cursorTop < 0) return;
                 Console.SetCursorPosition(buf.CursorStart, cursorTop);
 
                 Console.Write(ResetColorCode);
@@ -327,6 +330,7 @@ namespace ConsoleInteractive {
             }
 
             private static void ClearSingleSuggestionPopup(BgMessageBuffer buf, int cursorTop) {
+                if (cursorTop < 0) return;
                 Console.SetCursorPosition(buf.CursorStart, cursorTop);
                 Console.Write(buf.Text);
                 Console.Write(ResetColorCode);

--- a/ConsoleInteractive/ConsoleInteractive/ConsoleSuggestion.cs
+++ b/ConsoleInteractive/ConsoleInteractive/ConsoleSuggestion.cs
@@ -1,0 +1,560 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace ConsoleInteractive {
+    public static class ConsoleSuggestion {
+        private const int MaxSuggestions = 6, MaxSuggestionLength = 18;
+
+        private static bool InUse = false;
+
+        private static bool alreadyTriggerTab = false, lastKeyIsTab = false, hidePopup = false;
+
+        private static Tuple<int, int> TargetTextRange = new(1, 1), LastTextRange = new(1, 1);
+
+        private static int StartIndex = 0, PopupWidth = 0;
+
+        private static int ChoosenIndex = 0, ViewTop = 0, ViewBottom = 0;
+
+        private static Suggestion[] Suggestions = Array.Empty<Suggestion>();
+
+
+        internal static void OnWriteLine(string message, int linesAdded) {
+            if (InUse) DrawHelper.ClearSuggestionPopup(linesAdded);
+            DrawHelper.AddMessage(message);
+            if (InUse) DrawHelper.DrawSuggestionPopup();
+        }
+
+        internal static void OnInputUpdate() {
+            lastKeyIsTab = false;
+        }
+
+        internal static bool HandleEscape() {
+            lock (InternalContext.WriteLock) {
+                if (InUse) {
+                    hidePopup = true;
+                    ClearSuggestions();
+                    return true;
+                } else {
+                    return false;
+                }
+            }
+        }
+
+        internal static bool HandleTab() {
+            lock (InternalContext.WriteLock) {
+                if (hidePopup) {
+                    hidePopup = false;
+                    InUse = true;
+                    DrawHelper.DrawSuggestionPopup();
+                    return true;
+                } else if (InUse) {
+                    if (alreadyTriggerTab) {
+                        if (lastKeyIsTab)
+                            HandleDownArrow();
+                        ConsoleBuffer.Replace(LastTextRange.Item1, LastTextRange.Item2, Suggestions[ChoosenIndex].Text);
+                    } else {
+                        ConsoleBuffer.Replace(TargetTextRange.Item1, TargetTextRange.Item2, Suggestions[ChoosenIndex].Text);
+                    }
+                    LastTextRange = new(TargetTextRange.Item1, ConsoleBuffer.BufferPosition);
+                    alreadyTriggerTab = true;
+                    lastKeyIsTab = true;
+                    DrawHelper.RedrawOnTab();
+                    return true;
+                } else {
+                    return false;
+                }
+            }
+        }
+
+        internal static bool HandleUpArrow() {
+            lock (InternalContext.WriteLock) {
+                if (InUse) {
+                    lastKeyIsTab = false;
+                    if (ChoosenIndex == 0) {
+                        ChoosenIndex = Suggestions.Length - 1;
+                        ViewTop = Math.Max(0, Suggestions.Length - MaxSuggestions);
+                        ViewBottom = Suggestions.Length;
+                        DrawHelper.DrawSuggestionPopup(refreshMsgBuf: false);
+                    } else {
+                        --ChoosenIndex;
+                        if (ChoosenIndex == ViewTop && ViewTop != 0) {
+                            --ViewTop;
+                            --ViewBottom;
+                            DrawHelper.DrawSuggestionPopup(refreshMsgBuf: false);
+                        } else {
+                            DrawHelper.RedrawOnArrowKey(offset: 1);
+                        }
+                    }
+                    return true;
+                } else {
+                    return false;
+                }
+            }
+        }
+
+        internal static bool HandleDownArrow() {
+            lock (InternalContext.WriteLock) {
+                if (InUse) {
+                    lastKeyIsTab = false;
+                    if (ChoosenIndex == Suggestions.Length - 1) {
+                        ChoosenIndex = 0;
+                        ViewTop = 0;
+                        ViewBottom = Math.Min(Suggestions.Length, MaxSuggestions);
+                        DrawHelper.DrawSuggestionPopup(refreshMsgBuf: false);
+                    } else {
+                        ++ChoosenIndex;
+                        if (ChoosenIndex == ViewBottom - 1 && ViewBottom != Suggestions.Length) {
+                            ++ViewTop;
+                            ++ViewBottom;
+                            DrawHelper.DrawSuggestionPopup(refreshMsgBuf: false);
+                        } else {
+                            DrawHelper.RedrawOnArrowKey(offset: -1);
+                        }
+                    }
+                    return true;
+                } else {
+                    return false;
+                }
+            }
+        }
+
+        internal static void HandleEnter() {
+            ClearSuggestions();
+        }
+
+        public static void UpdateSuggestions(Suggestion[] Suggestions, Tuple<int, int> range) {
+            int maxLength = 0;
+            foreach (Suggestion sug in Suggestions)
+                maxLength = Math.Max(maxLength, sug.ShortText.Length);
+
+            if (Suggestions.Length == 0 || maxLength == 0) {
+                ClearSuggestions();
+                return;
+            }
+
+            lock (InternalContext.WriteLock) {
+                if (InUse)
+                    DrawHelper.ClearSuggestionPopup();
+
+                ConsoleSuggestion.Suggestions = Suggestions;
+
+                TargetTextRange = range;
+                StartIndex = range.Item1 - 1;
+
+                PopupWidth = maxLength + 2;
+
+                ChoosenIndex = 0;
+
+                ViewTop = 0;
+                ViewBottom = Math.Min(Suggestions.Length, MaxSuggestions);
+
+                if (!hidePopup) {
+                    InUse = true;
+                    DrawHelper.DrawSuggestionPopup();
+                }
+
+                alreadyTriggerTab = false;
+                lastKeyIsTab = false;
+            }
+        }
+
+        public static void ClearSuggestions() {
+            lock (InternalContext.WriteLock) {
+                if (InUse) {
+                    InUse = false;
+                    DrawHelper.ClearSuggestionPopup();
+                } else if (hidePopup) {
+                    hidePopup = false;
+                }
+            }
+        }
+
+        public class Suggestion {
+            public string ShortText;
+            public string Text, Type;
+
+            public Suggestion(string text, string type) {
+                Text = text;
+                Type = type;
+                if (Text.Length <= MaxSuggestionLength) {
+                    ShortText = Text;
+                } else {
+                    int half = MaxSuggestionLength / 2;
+                    ShortText = Text[..(half - 1)] + (MaxSuggestionLength % 2 == 0 ? ".." : "...") + Text[(Text.Length - half + 1)..];
+                }
+            }
+        }
+
+        private static class DrawHelper {
+            private const string NormalBgColorCode = "\u001b[100m"; // Bright Black (Gray)
+            private const string NormalColorCode = "\u001b[97m"; // Bright White
+
+            private const string ArrowColorCode = "\u001b[37m"; // White
+
+            private const string HighlightBgColorCode = "\u001b[43m"; // Yellow
+            private const string HighlightColorCode = "\u001b[97m"; // Bright White
+
+            private const string ResetColorCode = "\u001b[0m";
+
+            private static int LastDrawStartPos = -1;
+            private static readonly BgMessageBuffer[] BgBuffer = new BgMessageBuffer[MaxSuggestions];
+
+            internal static void DrawSuggestionPopup(bool refreshMsgBuf = true) {
+                BgMessageBuffer[] messageBuffers = Array.Empty<BgMessageBuffer>();
+                int curBufIdx = -1, nextMessageIdx = 0;
+                LastDrawStartPos = GetDrawStartPos();
+                InternalContext.SetCursorVisible(false);
+                int top = InternalContext.CurrentCursorTopPos, left = InternalContext.CurrentCursorLeftPos;
+                for (int i = ViewBottom - 1; i >= ViewTop; --i) {
+                    if (refreshMsgBuf) {
+                        if (curBufIdx < 0) {
+                            messageBuffers = GetBgMessageBuffer(RecentMessageHandler.GetRecentMessage(nextMessageIdx), LastDrawStartPos, PopupWidth);
+                            curBufIdx = messageBuffers.Length - 1;
+                            ++nextMessageIdx;
+                        }
+                        BgBuffer[i - ViewTop] = messageBuffers[curBufIdx];
+                        --curBufIdx;
+                    }
+                    DrawSingleSuggestionPopup(i, BgBuffer[i - ViewTop], cursorTop: top - (ViewBottom - i));
+                }
+                Console.SetCursorPosition(left, top);
+                InternalContext.SetCursorVisible(true);
+            }
+
+            internal static void ClearSuggestionPopup(int linesAdded = 0) {
+                int DisplaySuggestionsCnt = Math.Min(MaxSuggestions, Suggestions.Length); // Todo: head
+                int drawStartPos = GetDrawStartPos();
+                InternalContext.SetCursorVisible(false);
+                int top = InternalContext.CurrentCursorTopPos, left = InternalContext.CurrentCursorLeftPos;
+                Console.Write(ResetColorCode);
+                for (int i = 0; i < DisplaySuggestionsCnt; ++i) {
+                    if (linesAdded > 0 && i >= linesAdded && drawStartPos == LastDrawStartPos) break;
+                    ClearSingleSuggestionPopup(BgBuffer[i], cursorTop: top - (DisplaySuggestionsCnt - i) - linesAdded);
+                }
+                Console.SetCursorPosition(left, top);
+                InternalContext.SetCursorVisible(true);
+            }
+
+            internal static void RedrawOnArrowKey(int offset) {
+                InternalContext.SetCursorVisible(false);
+                int top = InternalContext.CurrentCursorTopPos, left = InternalContext.CurrentCursorLeftPos;
+
+                int cursorTop = top - (ViewBottom - ChoosenIndex);
+                DrawSingleSuggestionPopup(ChoosenIndex, BgBuffer[ChoosenIndex - ViewTop], cursorTop);
+                DrawSingleSuggestionPopup(ChoosenIndex + offset, BgBuffer[ChoosenIndex - ViewTop + offset], cursorTop + offset);
+
+                Console.SetCursorPosition(left, top);
+                InternalContext.SetCursorVisible(true);
+            }
+
+            internal static void RedrawOnTab() {
+                if (GetDrawStartPos() != LastDrawStartPos) {
+                    ClearSuggestionPopup();
+                    DrawSuggestionPopup(refreshMsgBuf: true);
+                }
+            }
+
+            internal static void AddMessage(string message) {
+                RecentMessageHandler.AddMessage(message);
+            }
+
+            private static int GetDrawStartPos() {
+                return Math.Max(0, Math.Min(InternalContext.CursorLeftPosLimit - PopupWidth, StartIndex + ConsoleBuffer.PrefixTotalLength - ConsoleBuffer.BufferOutputAnchor));
+            }
+
+            private static void DrawSingleSuggestionPopup(int index, BgMessageBuffer buf, int cursorTop) {
+                Console.SetCursorPosition(buf.CursorStart, cursorTop);
+
+                Console.Write(ResetColorCode);
+                if (buf.StartSpace)
+                    Console.Write(' ');
+
+                Console.Write(NormalBgColorCode);
+
+                Console.Write(ArrowColorCode);
+                if (index == ViewTop && ViewTop != 0)
+                    Console.Write('↑');
+                else if (index + 1 == ViewBottom && ViewBottom != Suggestions.Length)
+                    Console.Write('↓');
+                else if (index == ChoosenIndex)
+                    Console.Write('>');
+                else
+                    Console.Write(' ');
+
+                if (index == ChoosenIndex) {
+                    if (HighlightColorCode != ArrowColorCode)
+                        Console.Write(HighlightColorCode);
+                    if (HighlightBgColorCode != NormalBgColorCode)
+                        Console.Write(HighlightBgColorCode);
+                    Console.Write(Suggestions[index].ShortText);
+                    Console.Write(new string(' ', PopupWidth - 2 - Suggestions[index].ShortText.Length));
+                    if (HighlightBgColorCode != NormalBgColorCode)
+                        Console.Write(NormalBgColorCode);
+                } else {
+                    Console.Write(NormalColorCode);
+                    Console.Write(Suggestions[index].ShortText);
+                    Console.Write(new string(' ', PopupWidth - 2 - Suggestions[index].ShortText.Length));
+                }
+
+                Console.Write(ArrowColorCode);
+                if (index == ViewTop && ViewTop != 0)
+                    Console.Write('↑');
+                else if (index + 1 == ViewBottom && ViewBottom != Suggestions.Length)
+                    Console.Write('↓');
+                else if (index == ChoosenIndex)
+                    Console.Write('<');
+                else
+                    Console.Write(' ');
+
+                Console.Write(ResetColorCode);
+                if (buf.EndSpace)
+                    Console.Write(' ');
+            }
+
+            private static void ClearSingleSuggestionPopup(BgMessageBuffer buf, int cursorTop) {
+                Console.SetCursorPosition(buf.CursorStart, cursorTop);
+                Console.Write(buf.Text);
+                Console.Write(ResetColorCode);
+                Console.Write(new string(' ', buf.AfterTextSpace));
+            }
+
+            private static BgMessageBuffer[] GetBgMessageBuffer(RecentMessageHandler.RecentMessage? msg, int start, int length) {
+                if (msg == null)
+                    return new BgMessageBuffer[1] { new BgMessageBuffer(start, start + length, length) };
+
+                int charIndex = 0;
+                char[] chars = msg.Message.ToCharArray();
+                List<BgMessageBuffer> buffers = new();
+
+                while (charIndex < chars.Length) {
+                    int curIndex = 0;
+                    int charStart, charEnd;
+
+                    string Text = string.Empty;
+                    bool StartSpace = false, EndSpace = false;
+                    int CursorStart, CutsorEnd, AfterTextSpace = 0;
+
+                    while (curIndex < start) {
+                        if (charIndex < chars.Length) {
+                            if (System.Globalization.CharUnicodeInfo.GetUnicodeCategory(chars[charIndex]) == System.Globalization.UnicodeCategory.OtherLetter) {
+                                if (curIndex + 2 > start) {
+                                    StartSpace = true;
+                                    break;
+                                }
+                                curIndex += 2;
+                            } else {
+                                curIndex += 1;
+                            }
+                            ++charIndex;
+                        } else {
+                            curIndex = start;
+                            break;
+                        }
+                    }
+                    charStart = charIndex;
+                    CursorStart = curIndex;
+
+                    int end = start + length;
+                    while (curIndex < end) {
+                        if (charIndex < chars.Length) {
+                            if (System.Globalization.CharUnicodeInfo.GetUnicodeCategory(chars[charIndex]) == System.Globalization.UnicodeCategory.OtherLetter)
+                                curIndex += 2;
+                            else
+                                curIndex += 1;
+
+                            if (curIndex > end)
+                                EndSpace = true;
+
+                            ++charIndex;
+                        } else {
+                            int last = end - curIndex;
+                            curIndex += last;
+                            AfterTextSpace += last;
+                            break;
+                        }
+                    }
+                    charEnd = charIndex;
+                    CutsorEnd = curIndex;
+
+                    if (charStart < charEnd) {
+                        StringBuilder sb = new();
+
+                        int bgIdx = GetLowerBoundColorCode(msg.ColorCodeBG, charStart);
+                        while (bgIdx < msg.ColorCodeBG.Length && msg.ColorCodeBG[bgIdx].Item1 < charStart)
+                            sb.Append(msg.ColorCodeBG[bgIdx++].Item2);
+
+                        int fgIdx = GetLowerBoundColorCode(msg.ColorCodeFG, charStart);
+                        while (fgIdx < msg.ColorCodeFG.Length && msg.ColorCodeFG[fgIdx].Item1 < charStart)
+                            sb.Append(msg.ColorCodeFG[fgIdx++].Item2);
+
+                        for (int i = charStart; i < charEnd; ++i) {
+                            while (bgIdx < msg.ColorCodeBG.Length && msg.ColorCodeBG[bgIdx].Item1 == i)
+                                sb.Append(msg.ColorCodeBG[bgIdx++].Item2);
+                            while (fgIdx < msg.ColorCodeFG.Length && msg.ColorCodeFG[fgIdx].Item1 == i)
+                                sb.Append(msg.ColorCodeFG[fgIdx++].Item2);
+                            sb.Append(chars[i]);
+                        }
+                        Text = sb.ToString();
+                    }
+
+                    buffers.Add(new BgMessageBuffer(CursorStart, CutsorEnd, AfterTextSpace, Text, StartSpace, EndSpace));
+
+                    while (curIndex < InternalContext.CursorLeftPosLimit) {
+                        if (charIndex < chars.Length) {
+                            if (System.Globalization.CharUnicodeInfo.GetUnicodeCategory(chars[charIndex]) == System.Globalization.UnicodeCategory.OtherLetter) {
+                                if (curIndex + 2 >= InternalContext.CursorLeftPosLimit)
+                                    break;
+                                curIndex += 2;
+                            } else {
+                                curIndex += 1;
+                            }
+                            ++charIndex;
+                        } else {
+                            break;
+                        }
+                    }
+                }
+
+                return buffers.ToArray();
+            }
+
+            private static int GetLowerBoundColorCode(Tuple<int, string>[] ColorCodes, int charStart) {
+                --charStart;
+                int left = 0, right = ColorCodes.Length - 1;
+                while (left < right) {
+                    int mid = (left + right) / 2;
+                    if (ColorCodes[mid].Item1 >= charStart)
+                        right = mid;
+                    else
+                        left = mid + 1;
+                }
+                return left;
+            }
+
+            private static class RecentMessageHandler {
+                private static int Count = 0, Index = 0;
+
+                private static readonly RecentMessage[] Messages = new RecentMessage[MaxSuggestions];
+
+                internal static void AddMessage(string message) {
+                    string[] lines = message.Split('\n');
+                    int startIdx = MaxSuggestions * (lines.Length / MaxSuggestions);
+                    for (int i = startIdx; i < lines.Length; i++) {
+                        Index = Count < MaxSuggestions ? Count++ : (Index + 1) % MaxSuggestions;
+                        Messages[Index] = new(lines[i]);
+                    }
+                }
+
+                internal static RecentMessage? GetRecentMessage(int index) {
+                    if (index >= Count)
+                        return null;
+                    RecentMessage message = Messages[(MaxSuggestions + Index - index) % MaxSuggestions];
+                    message.ParseColorCode();
+                    return message;
+                }
+
+                internal class RecentMessage {
+                    private readonly static Regex ContralCharRegex = new(@"[\u0000-\u001F]", RegexOptions.Compiled);
+                    private readonly static Regex EscapeCodeRegex = new(@"\u001B\[[\d;]+m", RegexOptions.Compiled);
+
+                    private readonly static Regex Fg3bitColorCode = new(@"^\u001B\[(?:3|9)[01234567]m$", RegexOptions.Compiled);
+                    private readonly static Regex Bg3bitColorCode = new(@"^\u001B\[(?:4|10)[01234567]m$", RegexOptions.Compiled);
+                    private readonly static Regex Fg8bitColorCode = new(@"^\u001B\[38;5;(?:1\d{2}|2[0-4]\d|[1-9]?\d|25[0-5])m$", RegexOptions.Compiled);
+                    private readonly static Regex Bg8bitColorCode = new(@"^\u001B\[48;5;(?:1\d{2}|2[0-4]\d|[1-9]?\d|25[0-5])m$", RegexOptions.Compiled);
+                    private readonly static Regex Fg24bitColorCode = new(@"^\u001B\[38;2(?:;(?:1\d{2}|2[0-4]\d|[1-9]?\d|25[0-5])){3}m$", RegexOptions.Compiled);
+                    private readonly static Regex Bg24bitColorCode = new(@"^\u001B\[48;2(?:;(?:1\d{2}|2[0-4]\d|[1-9]?\d|25[0-5])){3}m$", RegexOptions.Compiled);
+
+                    bool Parsed = false;
+
+                    public Tuple<int, string>[] ColorCodeFG = Array.Empty<Tuple<int, string>>();
+
+                    public Tuple<int, string>[] ColorCodeBG = Array.Empty<Tuple<int, string>>();
+
+                    public string Message = string.Empty, RawMessage = string.Empty;
+
+                    public RecentMessage(string message) {
+                        RawMessage = message;
+                    }
+
+                    public void ParseColorCode() {
+                        if (Parsed)
+                            return;
+
+                        List<Tuple<int, string>> fgColor = new(), bgColor = new();
+                        MatchCollection matchs = EscapeCodeRegex.Matches(RawMessage);
+                        int colorLen = 0;
+                        foreach (Match match in matchs) {
+                            int index = match.Index - colorLen;
+                            string code = match.Groups[0].Value;
+                            if (code == ResetColorCode)
+                                bgColor.Add(new(index, code));
+                            else if (IsForcegroundColorCode(code))
+                                fgColor.Add(new(index, code));
+                            else if (IsBackgroundColorCode(code))
+                                bgColor.Add(new(index, code));
+                            colorLen += match.Length;
+                        }
+
+                        Message = ContralCharRegex.Replace(EscapeCodeRegex.Replace(RawMessage, string.Empty), string.Empty);
+                        ColorCodeFG = fgColor.ToArray();
+                        ColorCodeBG = bgColor.ToArray();
+
+                        Parsed = true;
+                    }
+
+                    private static bool IsForcegroundColorCode(string code) {
+                        if (Fg3bitColorCode.IsMatch(code))
+                            return true;
+                        if (Fg8bitColorCode.IsMatch(code))
+                            return true;
+                        if (Fg24bitColorCode.IsMatch(code))
+                            return true;
+                        return false;
+                    }
+
+                    private static bool IsBackgroundColorCode(string code) {
+                        if (Bg3bitColorCode.IsMatch(code))
+                            return true;
+                        if (Bg8bitColorCode.IsMatch(code))
+                            return true;
+                        if (Bg24bitColorCode.IsMatch(code))
+                            return true;
+                        return false;
+                    }
+                }
+            }
+
+            private record BgMessageBuffer {
+                public BgMessageBuffer(int cursorStart, int cutsorEnd, int afterTextSpace) {
+                    CursorStart = cursorStart;
+                    CutsorEnd = cutsorEnd;
+                    StartSpace = false;
+                    EndSpace = false;
+                    Text = string.Empty;
+                    AfterTextSpace = afterTextSpace;
+                }
+
+                public BgMessageBuffer(int cursorStart, int cutsorEnd, int afterTextSpace, string text, bool startSpace, bool endSpace) {
+                    CursorStart = cursorStart;
+                    CutsorEnd = cutsorEnd;
+                    StartSpace = startSpace;
+                    EndSpace = endSpace;
+                    Text = text;
+                    AfterTextSpace = afterTextSpace;
+                }
+
+                public int CursorStart { get; init; }
+                public int CutsorEnd { get; init; }
+
+                public bool StartSpace { get; init; }
+                public bool EndSpace { get; init; }
+
+                public string Text { get; init; }
+
+                public int AfterTextSpace { get; init; }
+            }
+        }
+    }
+}

--- a/ConsoleInteractive/ConsoleInteractive/ConsoleSuggestion.cs
+++ b/ConsoleInteractive/ConsoleInteractive/ConsoleSuggestion.cs
@@ -423,11 +423,11 @@ namespace ConsoleInteractive {
             private static int GetLowerBoundColorCode(Tuple<int, string>[] ColorCodes, int charStart) {
                 int left = 0, right = ColorCodes.Length - 1;
                 while (left < right) {
-                    int mid = (left + right) / 2;
-                    if (ColorCodes[mid].Item1 >= charStart)
-                        right = mid;
+                    int mid = (left + right + 1) / 2;
+                    if (ColorCodes[mid].Item1 <= charStart)
+                        left = mid;
                     else
-                        left = mid + 1;
+                        right = mid - 1;
                 }
                 return left;
             }

--- a/ConsoleInteractive/ConsoleInteractive/ConsoleSuggestion.cs
+++ b/ConsoleInteractive/ConsoleInteractive/ConsoleSuggestion.cs
@@ -7,6 +7,7 @@ using Wcwidth;
 namespace ConsoleInteractive {
     public static class ConsoleSuggestion {
         public static bool EnableColor { get; set; } = true;
+        public static bool UseBasicArrow { get; set; } = false;
 
         public static int MaxSuggestionCount = 6, MaxSuggestionLength = 30;
 
@@ -304,8 +305,8 @@ namespace ConsoleInteractive {
             }
 
             internal string GetShortTooltip(int widthLimit) {
+                if (widthLimit <= 2) return new string('.', widthLimit);
                 widthLimit -= 2;
-                if (widthLimit <= 0) return string.Empty;
 
                 if (_cache != null && _cache.Item1 == widthLimit)
                     return _cache.Item2;
@@ -334,7 +335,7 @@ namespace ConsoleInteractive {
             internal static string TooltipColorCode = "\u001b[38;2;125;211;252m";         // Sky    30%  (#7dd3fc)
             internal static string HighlightTooltipColorCode = "\u001b[38;2;59;130;246m"; // Blue   50%  (#3b82f6)
 
-            internal static string ArrowColorCode = "\u001b[38;2;209;213;219m";           // Gray   30%  (#d1d5db)
+            internal static string ArrowColorCode = "\u001b[38;2;156;163;175m";           // Gray   40%  (#9ca3af)
 
             internal const string ResetColorCode = "\u001b[0m";
 
@@ -428,9 +429,9 @@ namespace ConsoleInteractive {
 
                 sb.Append(ArrowColorCode);
                 if (index == ViewTop && ViewTop != 0)
-                    sb.Append('↑');
+                    sb.Append(UseBasicArrow ? '^' : '↑');
                 else if (index + 1 == ViewBottom && ViewBottom != Suggestions.Length)
-                    sb.Append('↓');
+                    sb.Append(UseBasicArrow ? 'v' : '↓');
                 else if (index == ChoosenIndex)
                     sb.Append('>');
                 else
@@ -475,9 +476,9 @@ namespace ConsoleInteractive {
 
                 sb.Append(ArrowColorCode);
                 if (index == ViewTop && ViewTop != 0)
-                    sb.Append('↑');
+                    sb.Append(UseBasicArrow ? '^' : '↑');
                 else if (index + 1 == ViewBottom && ViewBottom != Suggestions.Length)
-                    sb.Append('↓');
+                    sb.Append(UseBasicArrow ? 'v' : '↓');
                 else if (index == ChoosenIndex)
                     sb.Append('<');
                 else

--- a/ConsoleInteractive/ConsoleInteractive/ConsoleSuggestion.cs
+++ b/ConsoleInteractive/ConsoleInteractive/ConsoleSuggestion.cs
@@ -758,7 +758,10 @@ namespace ConsoleInteractive {
                             int index = match.Index - colorLen;
                             string code = match.Groups[0].Value;
                             if (code == ResetColorCode)
+                            {
+                                fgColor.Add(new(index, code));
                                 bgColor.Add(new(index, code));
+                            }
                             else if (IsForcegroundColorCode(code))
                                 fgColor.Add(new(index, code));
                             else if (IsBackgroundColorCode(code))

--- a/ConsoleInteractive/ConsoleInteractive/ConsoleSuggestion.cs
+++ b/ConsoleInteractive/ConsoleInteractive/ConsoleSuggestion.cs
@@ -130,7 +130,7 @@ namespace ConsoleInteractive {
         }
 
         private static bool CheckIfNeedClear(Suggestion[] Suggestions, Tuple<int, int> range, int maxLength) {
-            if (Suggestions.Length < MaxSuggestionLength && ConsoleSuggestion.Suggestions.Length > MaxSuggestionLength)
+            if (Suggestions.Length < MaxSuggestionLength && ConsoleSuggestion.Suggestions.Length >= MaxSuggestionLength)
                 return true;
             if (ConsoleSuggestion.Suggestions.Length < MaxSuggestionLength && ConsoleSuggestion.Suggestions.Length > Suggestions.Length)
                 return true;

--- a/ConsoleInteractive/ConsoleInteractive/ConsoleWriter.cs
+++ b/ConsoleInteractive/ConsoleInteractive/ConsoleWriter.cs
@@ -33,7 +33,7 @@ namespace ConsoleInteractive {
     internal static class InternalWriter {
         private static int GetLineCntInTerminal(string value) {
             bool escape = false;
-            int lineCnt = 0, curIndex = 0;
+            int lineCnt = 1, curIndex = 0;
             foreach (char c in value) {
                 if (!escape && c == '\u001B') {
                     escape = true;
@@ -70,8 +70,6 @@ namespace ConsoleInteractive {
                     curIndex = 0;
                 }
             }
-            if (curIndex > 0)
-                ++lineCnt;
             return lineCnt;
         }
 

--- a/ConsoleInteractive/ConsoleInteractive/ConsoleWriter.cs
+++ b/ConsoleInteractive/ConsoleInteractive/ConsoleWriter.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Runtime.InteropServices;
+using System.Collections.Generic;
 using System.Text;
 using System.Text.RegularExpressions;
 using PInvoke;
@@ -8,6 +8,7 @@ using Wcwidth;
 namespace ConsoleInteractive {
     public static class ConsoleWriter {
         public static bool EnableColor { get; set; } = true;
+        public static bool UseVT100ColorCode { get; set; } = false;
 
         public static void Init() {
             SetWindowsConsoleAnsi();
@@ -16,7 +17,7 @@ namespace ConsoleInteractive {
         }
 
         private static void SetWindowsConsoleAnsi() {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            if (OperatingSystem.IsWindows()) {
                 Kernel32.GetConsoleMode(Kernel32.GetStdHandle(Kernel32.StdHandle.STD_OUTPUT_HANDLE), out var cModes);
                 Kernel32.SetConsoleMode(Kernel32.GetStdHandle(Kernel32.StdHandle.STD_OUTPUT_HANDLE), cModes | Kernel32.ConsoleBufferModes.ENABLE_VIRTUAL_TERMINAL_PROCESSING);
             }
@@ -29,11 +30,9 @@ namespace ConsoleInteractive {
         public static void WriteLineFormatted(string value) {
             InternalWriter.WriteLineFormatted(value);
         }
-
     }
 
     internal static class InternalWriter {
-        internal readonly static Regex ColorCodeRegex = new(@"\u001B\[[\d;]+m", RegexOptions.Compiled);
 
         /// <summary>
         /// Gets the number of lines and the width of the first line of the message.
@@ -87,22 +86,39 @@ namespace ConsoleInteractive {
             return new(lineCnt, firstLineLength);
         }
 
-        private static void Write(string value) {
+        internal static void WriteConsole(string value, List<Tuple<int, bool, ConsoleColor>>? colors = null) {
+            if (colors != null) {
+                int curIndex = 0;
+                foreach ((int idx, bool foreground, ConsoleColor color) in colors) {
+                    Console.Write(value[curIndex..idx]);
+                    curIndex = idx;
+                    if (foreground)
+                        Console.ForegroundColor = color;
+                    else
+                        Console.BackgroundColor = color;
+                }
+                Console.WriteLine(value[curIndex..]);
+            } else {
+                Console.WriteLine(value);
+            }
+        }
+
+        private static void Write(string value, List<Tuple<int, bool, ConsoleColor>>? colors = null) {
             (int linesAdded, int firstLineLength) = GetLineCountInTerminal(value);
 
             lock (InternalContext.WriteLock) {
                 ConsoleSuggestion.BeforeWrite(value, linesAdded);
 
-                if (Console.IsOutputRedirected) {
-                    Console.WriteLine(ConsoleWriter.EnableColor ? value : ColorCodeRegex.Replace(value, string.Empty));
-                } else {
+                if (!Console.IsOutputRedirected) {
                     if (InternalContext.BufferInitialized)
                         ConsoleBuffer.ClearVisibleUserInput(startPos: firstLineLength);
                     else
                         Console.CursorLeft = 0;
+                }
 
-                    Console.WriteLine(ConsoleWriter.EnableColor ? value : ColorCodeRegex.Replace(value, string.Empty));
+                WriteConsole(value, colors);
 
+                if (!Console.IsOutputRedirected) {
                     // Only redraw if we have a buffer initialized.
                     if (InternalContext.BufferInitialized)
                         ConsoleBuffer.RedrawInputArea(RedrawAll: true);
@@ -117,71 +133,125 @@ namespace ConsoleInteractive {
         }
 
         public static void WriteLineFormatted(string value) {
-            StringBuilder b = new();
-            var matches = InternalContext.FormatRegex.Matches(value);
+            if (!ConsoleWriter.EnableColor) {
+                Write(InternalContext.FormatRegex.Replace(value, string.Empty));
+                return;
+            }
 
+            var matches = InternalContext.FormatRegex.Matches(value);
             if (matches.Count == 0) {
                 Write(value);
                 return;
             }
 
-            var idx = value.IndexOf('§');
-            if (idx > 0) {
-                b.Append(value[..idx]);
-            }
-
+            int curIndex = 0;
             bool funkyMode = false;
+            StringBuilder sb = new(value.Length);
+            if (ConsoleWriter.UseVT100ColorCode) {
+                foreach (Match match in matches) {
+                    if (funkyMode)
+                        sb.Append('\u2588', match.Index - curIndex);
+                    else
+                        sb.Append(value.AsMemory(curIndex, match.Index - curIndex));
+                    curIndex = match.Index + match.Length;
 
-            foreach (Match match in matches) {
-                if (match.Groups[1].Value == "§r") {
-                    funkyMode = false;
+                    string matchValue = match.Groups[1].Value;
+                    if (matchValue[1] == '§') { // background
+                        switch (matchValue[2]) {
+                            case '0': sb.Append("\u001B[40m"); break;
+                            case '1': sb.Append("\u001B[44m"); break;
+                            case '2': sb.Append("\u001B[42m"); break;
+                            case '3': sb.Append("\u001B[46m"); break;
+                            case '4': sb.Append("\u001B[41m"); break;
+                            case '5': sb.Append("\u001B[45m"); break;
+                            case '6': sb.Append("\u001B[43m"); break;
+                            case '7': sb.Append("\u001B[100m"); break;
+                            case '8': sb.Append("\u001B[47m"); break;
+                            case '9': sb.Append("\u001B[104m"); break;
+                            case 'a': sb.Append("\u001B[102m"); break;
+                            case 'b': sb.Append("\u001B[106m"); break;
+                            case 'c': sb.Append("\u001B[101m"); break;
+                            case 'd': sb.Append("\u001B[105m"); break;
+                            case 'e': sb.Append("\u001B[103m"); break;
+                            case 'f': sb.Append("\u001B[107m"); break;
+                            case 'r': funkyMode = false; sb.Append("\u001B[0m"); break;
+                        }
+                    } else { // foreground
+                        switch (matchValue[1]) {
+                            case '0': sb.Append("\u001B[30m"); break;
+                            case '1': sb.Append("\u001B[34m"); break;
+                            case '2': sb.Append("\u001B[32m"); break;
+                            case '3': sb.Append("\u001B[36m"); break;
+                            case '4': sb.Append("\u001B[31m"); break;
+                            case '5': sb.Append("\u001B[35m"); break;
+                            case '6': sb.Append("\u001B[33m"); break;
+                            case '7': sb.Append("\u001B[90m"); break;
+                            case '8': sb.Append("\u001B[37m"); break;
+                            case '9': sb.Append("\u001B[94m"); break;
+                            case 'a': sb.Append("\u001B[92m"); break;
+                            case 'b': sb.Append("\u001B[96m"); break;
+                            case 'c': sb.Append("\u001B[91m"); break;
+                            case 'd': sb.Append("\u001B[95m"); break;
+                            case 'e': sb.Append("\u001B[93m"); break;
+                            case 'f': sb.Append("\u001B[97m"); break;
+                            case 'k': funkyMode = true; break;
+                            case 'l': sb.Append("\u001B[1m"); break;
+                            case 'm': sb.Append("\u001B[9m"); break;
+                            case 'n': sb.Append("\u001B[4m"); break;
+                            case 'o': sb.Append("\u001B[3m"); break;
+                            case 'r': funkyMode = false; sb.Append("\u001B[0m"); break;
+                        }
+                    }
                 }
+                sb.Append(value.AsMemory(curIndex, value.Length - curIndex));
+                if (matches[^1].Value[^1] != 'r')
+                    sb.Append("\u001b[0m");
+                Write(sb.ToString());
+            } else {
+                List<Tuple<int, bool, ConsoleColor>> colors = new();
+                foreach (Match match in matches) {
+                    if (funkyMode)
+                        sb.Append('\u2588', match.Index - curIndex);
+                    else
+                        sb.Append(value.AsMemory(curIndex, match.Index - curIndex));
+                    curIndex = match.Index + match.Length;
 
-                if (match.Groups[1].Value == "§k") {
-                    funkyMode = true;
+                    string matchValue = match.Groups[1].Value;
+
+                    bool isForeground = matchValue[1] != '§';
+                    switch (isForeground ? matchValue[1] : matchValue[2]) {
+                        case '0': colors.Add(new(sb.Length, isForeground, ConsoleColor.Gray)); break;
+                        case '1': colors.Add(new(sb.Length, isForeground, ConsoleColor.DarkBlue)); break;
+                        case '2': colors.Add(new(sb.Length, isForeground, ConsoleColor.DarkGreen)); break;
+                        case '3': colors.Add(new(sb.Length, isForeground, ConsoleColor.DarkCyan)); break;
+                        case '4': colors.Add(new(sb.Length, isForeground, ConsoleColor.DarkRed)); break;
+                        case '5': colors.Add(new(sb.Length, isForeground, ConsoleColor.DarkMagenta)); break;
+                        case '6': colors.Add(new(sb.Length, isForeground, ConsoleColor.DarkYellow)); break;
+                        case '7': colors.Add(new(sb.Length, isForeground, ConsoleColor.Gray)); break;
+                        case '8': colors.Add(new(sb.Length, isForeground, ConsoleColor.DarkGray)); break;
+                        case '9': colors.Add(new(sb.Length, isForeground, ConsoleColor.Blue)); break;
+                        case 'a': colors.Add(new(sb.Length, isForeground, ConsoleColor.Green)); break;
+                        case 'b': colors.Add(new(sb.Length, isForeground, ConsoleColor.Cyan)); break;
+                        case 'c': colors.Add(new(sb.Length, isForeground, ConsoleColor.Red)); break;
+                        case 'd': colors.Add(new(sb.Length, isForeground, ConsoleColor.Magenta)); break;
+                        case 'e': colors.Add(new(sb.Length, isForeground, ConsoleColor.Yellow)); break;
+                        case 'f': colors.Add(new(sb.Length, isForeground, ConsoleColor.White)); break;
+                        case 'k': funkyMode = true; break;
+                        case 'l': break;
+                        case 'm': break;
+                        case 'n': break;
+                        case 'o': break;
+                        case 'r':
+                            funkyMode = false;
+                            colors.Add(new(sb.Length, isForeground, isForeground ? ConsoleColor.White : ConsoleColor.Black));
+                            break;
+                    }
                 }
-
-                if (funkyMode) {
-                    b.Append(match.Groups[1]);
-
-                    var charArr = new char[match.Groups[2].Length];
-                    Array.Fill(charArr, '\u2588'); // Square character in place of §k.
-                    b.Append(new string(charArr));
-                    continue;
-                }
-
-                b.Append(match.Groups[1].Value + match.Groups[2].Value);
+                sb.Append(value.AsMemory(curIndex, value.Length - curIndex));
+                if (matches[^1].Value[^1] != 'r')
+                    colors.Add(new(sb.Length, true, ConsoleColor.White));
+                Write(sb.ToString(), colors);
             }
-
-            b.Append("§r");
-            b.Replace("§0", "\u001B[30m")  // Black
-             .Replace("§1", "\u001B[34m")  // Dark Blue
-             .Replace("§2", "\u001B[32m")  // Dark Green
-             .Replace("§3", "\u001B[36m")  // Dark Aqua
-             .Replace("§4", "\u001B[31m")  // Dark Red
-             .Replace("§5", "\u001B[35m")  // Dark Purple
-             .Replace("§6", "\u001B[33m")  // Gold
-             .Replace("§7", "\u001B[90m")  // Gray
-             .Replace("§8", "\u001B[37m")  // Dark Gray
-             .Replace("§9", "\u001B[94m")  // Blue
-             .Replace("§a", "\u001B[92m")  // Green
-             .Replace("§b", "\u001B[96m")  // Aqua
-             .Replace("§c", "\u001B[91m")  // Red
-             .Replace("§d", "\u001B[95m")  // Light Purple
-             .Replace("§e", "\u001B[93m")  // Yellow
-             .Replace("§f", "\u001B[97m")  // White
-             .Replace("§k", "")            // Obfuscated
-             .Replace("§l", "\u001B[1m")   // Bold
-             .Replace("§m", "\u001B[9m")   // Strikethrough
-             .Replace("§n", "\u001B[4m")   // Underline
-             .Replace("§o", "\u001B[3m")   // Italic
-             .Replace("§r", "\u001B[0m")   // Reset
-             .Replace("§w", "\u001B[41m")  // Custom: Background Red
-             .Replace("§x", "\u001B[43m")  // Custom: Background Yellow
-             .Replace("§y", "\u001B[42m")  // Custom: Background Green
-             .Replace("§z", "\u001B[100m");// Custom: Background Gray
-
-            Write(b.ToString());
         }
     }
 }

--- a/ConsoleInteractive/ConsoleInteractive/ConsoleWriter.cs
+++ b/ConsoleInteractive/ConsoleInteractive/ConsoleWriter.cs
@@ -2,7 +2,6 @@
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading;
 using PInvoke;
 using Wcwidth;
 

--- a/ConsoleInteractive/ConsoleInteractive/ConsoleWriter.cs
+++ b/ConsoleInteractive/ConsoleInteractive/ConsoleWriter.cs
@@ -40,6 +40,9 @@ namespace ConsoleInteractive {
         /// Gets the number of lines and the width of the first line of the message.
         /// </summary>
         private static Tuple<int, int> GetLineCountInTerminal(string value) {
+            if (Console.IsOutputRedirected)
+                return new(0, 0);
+
             bool escape = false;
             int lineCnt = 0, cursorPos = 0, firstLineLength = -1;
             int bufWidth = Console.BufferWidth;

--- a/ConsoleInteractive/ConsoleInteractive/ConsoleWriter.cs
+++ b/ConsoleInteractive/ConsoleInteractive/ConsoleWriter.cs
@@ -39,6 +39,7 @@ namespace ConsoleInteractive {
         private static Tuple<int, int> GetLineCountInTerminal(string value) {
             bool escape = false;
             int lineCnt = 0, cursorPos = 0, firstLineLength = -1;
+            int bufWidth = Console.BufferWidth;
             foreach (char c in value) {
                 if (!escape && c == '\u001B') {
                     escape = true;
@@ -58,7 +59,7 @@ namespace ConsoleInteractive {
                 }
 
                 int width = Math.Max(0, UnicodeCalculator.GetWidth(c));
-                if (cursorPos + width > InternalContext.CursorLeftPosLimit) {
+                if (cursorPos + width > bufWidth) {
                     if (lineCnt == 0)
                         firstLineLength = cursorPos;
                     ++lineCnt;
@@ -67,7 +68,7 @@ namespace ConsoleInteractive {
                     cursorPos += width;
                 }
 
-                if (cursorPos >= InternalContext.CursorLeftPosLimit) {
+                if (cursorPos >= bufWidth) {
                     if (lineCnt == 0)
                         firstLineLength = cursorPos;
                     ++lineCnt;
@@ -76,7 +77,7 @@ namespace ConsoleInteractive {
             }
             if (firstLineLength == -1)
                 firstLineLength = cursorPos;
-            if (lineCnt == 0)
+            if (lineCnt == 0 || cursorPos > 0)
                 ++lineCnt;
             return new(lineCnt, firstLineLength);
         }

--- a/ConsoleInteractive/ConsoleInteractive/ConsoleWriter.cs
+++ b/ConsoleInteractive/ConsoleInteractive/ConsoleWriter.cs
@@ -77,6 +77,7 @@ namespace ConsoleInteractive {
             int linesAdded = GetLineCntInTerminal(value);
 
             lock (InternalContext.WriteLock) {
+                ConsoleSuggestion.BeforeWriteLine(value, linesAdded);
 
                 // If the buffer is initialized, then we should get the current cursor position
                 // because we potentially are writing over user input.
@@ -113,7 +114,7 @@ namespace ConsoleInteractive {
                 Console.SetCursorPosition(currentCursorPos, InternalContext.CurrentCursorTopPos);
                 InternalContext.SetLeftCursorPosition(currentCursorPos);
 
-                ConsoleSuggestion.OnWriteLine(value, linesAdded);
+                ConsoleSuggestion.AfterWriteLine();
             }
         }
 

--- a/ConsoleInteractive/ConsoleInteractive/ConsoleWriter.cs
+++ b/ConsoleInteractive/ConsoleInteractive/ConsoleWriter.cs
@@ -152,7 +152,7 @@ namespace ConsoleInteractive {
                     if (funkyMode)
                         sb.Append('\u2588', match.Index - curIndex);
                     else
-                        sb.Append(value.AsMemory(curIndex, match.Index - curIndex));
+                        sb.Append(value.AsSpan(curIndex, match.Index - curIndex));
                     curIndex = match.Index + match.Length;
 
                     string matchValue = match.Groups[1].Value;
@@ -203,7 +203,7 @@ namespace ConsoleInteractive {
                         }
                     }
                 }
-                sb.Append(value.AsMemory(curIndex, value.Length - curIndex));
+                sb.Append(value.AsSpan(curIndex, value.Length - curIndex));
                 if (matches[^1].Value[^1] != 'r')
                     sb.Append("\u001b[0m");
                 Write(sb.ToString());
@@ -213,7 +213,7 @@ namespace ConsoleInteractive {
                     if (funkyMode)
                         sb.Append('\u2588', match.Index - curIndex);
                     else
-                        sb.Append(value.AsMemory(curIndex, match.Index - curIndex));
+                        sb.Append(value.AsSpan(curIndex, match.Index - curIndex));
                     curIndex = match.Index + match.Length;
 
                     string matchValue = match.Groups[1].Value;
@@ -247,7 +247,7 @@ namespace ConsoleInteractive {
                             break;
                     }
                 }
-                sb.Append(value.AsMemory(curIndex, value.Length - curIndex));
+                sb.Append(value.AsSpan(curIndex, value.Length - curIndex));
                 if (matches[^1].Value[^1] != 'r')
                     colors.Add(new(sb.Length, true, ConsoleColor.White));
                 Write(sb.ToString(), colors);

--- a/ConsoleInteractive/ConsoleInteractive/InternalContext.cs
+++ b/ConsoleInteractive/ConsoleInteractive/InternalContext.cs
@@ -7,7 +7,8 @@ namespace ConsoleInteractive {
         internal static object UserInputBufferLock = new();
         internal static object BackreadBufferLock = new();
 
-        internal static Regex FormatRegex = new("(§[0-9a-fk-orw-z])((?:[^§]|§[^0-9a-fk-orw-z])*)", RegexOptions.Compiled);
+        internal readonly static Regex VT100CodeRegex = new(@"\u001B\[[\d;]+m", RegexOptions.Compiled);
+        internal readonly static Regex FormatRegex = new("(§([0-9a-fk-or]|(?:§[0-9a-fr])))", RegexOptions.Compiled);
 
         internal static volatile bool _suppressInput = false;
         internal static volatile bool BufferInitialized = false;

--- a/ConsoleInteractive/ConsoleInteractive/InternalContext.cs
+++ b/ConsoleInteractive/ConsoleInteractive/InternalContext.cs
@@ -55,9 +55,9 @@ namespace ConsoleInteractive {
         internal static void SetCursorVisible(bool visible) {
 
             // It's useful to have the cursor visible in debug situations
-            #if DEBUG
-                return;
-            #endif
+#if DEBUG
+            return;
+#endif
 
             Console.CursorVisible = visible;
         }

--- a/ConsoleInteractive/ConsoleInteractive/InternalContext.cs
+++ b/ConsoleInteractive/ConsoleInteractive/InternalContext.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Text.RegularExpressions;
-using System.Threading;
 
 namespace ConsoleInteractive {
     internal static class InternalContext {

--- a/ConsoleInteractive/ConsoleInteractive/InternalContext.cs
+++ b/ConsoleInteractive/ConsoleInteractive/InternalContext.cs
@@ -10,8 +10,6 @@ namespace ConsoleInteractive {
 
         internal static Regex FormatRegex = new("(§[0-9a-fk-orw-z])((?:[^§]|§[^0-9a-fk-orw-z])*)", RegexOptions.Compiled);
 
-        internal static volatile int CursorLeftPosLimit = Console.BufferWidth;
-
         internal static volatile bool _suppressInput = false;
         internal static volatile bool BufferInitialized = false;
 

--- a/ConsoleInteractive/ConsoleInteractive/InternalContext.cs
+++ b/ConsoleInteractive/ConsoleInteractive/InternalContext.cs
@@ -5,11 +5,13 @@ using System.Threading;
 namespace ConsoleInteractive {
     internal static class InternalContext {
         internal static object WriteLock = new();
+        internal static object UserInputBufferLock = new();
+        internal static object BackreadBufferLock = new();
+
         internal static Regex FormatRegex = new("(§[0-9a-fk-orw-z])((?:[^§]|§[^0-9a-fk-orw-z])*)", RegexOptions.Compiled);
-        internal static volatile int CurrentCursorLeftPos = 0;
-        internal static volatile int CurrentCursorTopPos = 0;
+
         internal static volatile int CursorLeftPosLimit = Console.BufferWidth;
-        internal static volatile int CursorTopPosLimit = Console.BufferHeight;
+
         internal static volatile bool _suppressInput = false;
         internal static volatile bool BufferInitialized = false;
 
@@ -20,70 +22,18 @@ namespace ConsoleInteractive {
                 if (value) {
                     ConsoleBuffer.ClearVisibleUserInput();
                 }
-                ConsoleBuffer.RedrawInput();
+                ConsoleBuffer.RedrawInputArea();
                 ConsoleBuffer.MoveToEndBufferPosition();
             }
         }
 
-        internal static void SetLeftCursorPosition(int leftPos) {
-            if (CurrentCursorTopPos == CursorTopPosLimit) {
-                Interlocked.Exchange(ref CurrentCursorTopPos, CursorTopPosLimit - 1);
-            }
-
-            Console.SetCursorPosition(leftPos, CurrentCursorTopPos);
-            Interlocked.Exchange(ref CurrentCursorLeftPos, leftPos);
-        }
-
-        internal static void SetTopCursorPosition(int topPos) {
-            if (CurrentCursorTopPos == CursorTopPosLimit) {
-                Interlocked.Exchange(ref CurrentCursorTopPos, CursorTopPosLimit - 1);
-            }
-
-            Console.SetCursorPosition(CurrentCursorLeftPos, topPos);
-            Interlocked.Exchange(ref CurrentCursorTopPos, topPos);
-        }
-
-        internal static void SetCursorPosition(int leftPos, int topPos) {
-            SetLeftCursorPosition(leftPos);
-            SetTopCursorPosition(topPos);
-        }
-
-        internal static void ResetCursorPosition() {
-            Console.SetCursorPosition(CurrentCursorLeftPos, CurrentCursorTopPos);
-        }
-
         internal static void SetCursorVisible(bool visible) {
-
             // It's useful to have the cursor visible in debug situations
-#if DEBUG
-            return;
-#endif
+            #if DEBUG
+                return;
+            #endif
 
             Console.CursorVisible = visible;
-        }
-
-        internal static void IncrementLeftPos(int amount = 1) {
-            if (CursorLeftPosLimit <= CurrentCursorLeftPos + 1)
-                return;
-            CurrentCursorLeftPos = Interlocked.Add(ref CurrentCursorLeftPos, amount);
-            if (SuppressInput) return;
-            Console.SetCursorPosition(CurrentCursorLeftPos, CurrentCursorTopPos);
-        }
-
-        internal static void DecrementLeftPos(int amount = 1) {
-            if (CurrentCursorLeftPos == 0)
-                return;
-            CurrentCursorLeftPos = Interlocked.Add(ref CurrentCursorLeftPos, -amount);
-            if (SuppressInput) return;
-            Console.SetCursorPosition(CurrentCursorLeftPos, CurrentCursorTopPos);
-        }
-
-        internal static void IncrementTopPos() {
-            if (CursorTopPosLimit <= CurrentCursorTopPos + 1)
-                return;
-            CurrentCursorTopPos = Interlocked.Increment(ref CurrentCursorTopPos);
-            if (SuppressInput) return;
-            Console.SetCursorPosition(CurrentCursorLeftPos, CurrentCursorTopPos);
         }
     }
 }

--- a/ConsoleInteractive/ConsoleInteractive/InternalContext.cs
+++ b/ConsoleInteractive/ConsoleInteractive/InternalContext.cs
@@ -2,13 +2,13 @@
 using System.Text.RegularExpressions;
 
 namespace ConsoleInteractive {
-    internal static class InternalContext {
+    internal static partial class InternalContext {
         internal static object WriteLock = new();
         internal static object UserInputBufferLock = new();
         internal static object BackreadBufferLock = new();
 
-        internal readonly static Regex VT100CodeRegex = new(@"\u001B\[[\d;]+m", RegexOptions.Compiled);
-        internal readonly static Regex FormatRegex = new("(§([0-9a-fk-or]|(?:§[0-9a-fr])))", RegexOptions.Compiled);
+        internal readonly static Regex VT100CodeRegex = GetVT100CodeRegex();
+        internal readonly static Regex FormatRegex = GetFormatRegex();
 
         internal static volatile bool _suppressInput = false;
         internal static volatile bool BufferInitialized = false;
@@ -33,5 +33,11 @@ namespace ConsoleInteractive {
 
             Console.CursorVisible = visible;
         }
+
+        [GeneratedRegex("\\u001B\\[[\\d;]+m", RegexOptions.Compiled)]
+        private static partial Regex GetVT100CodeRegex();
+
+        [GeneratedRegex("(§([0-9a-fk-or]|(?:§[0-9a-fr])))", RegexOptions.Compiled)]
+        private static partial Regex GetFormatRegex();
     }
 }

--- a/ConsoleInteractive/ConsoleInteractive/InternalContext.cs
+++ b/ConsoleInteractive/ConsoleInteractive/InternalContext.cs
@@ -12,7 +12,7 @@ namespace ConsoleInteractive {
         internal static volatile int CursorTopPosLimit = Console.BufferHeight;
         internal static volatile bool _suppressInput = false;
         internal static volatile bool BufferInitialized = false;
-        
+
         internal static bool SuppressInput {
             get { return _suppressInput; }
             set {
@@ -29,7 +29,7 @@ namespace ConsoleInteractive {
             if (CurrentCursorTopPos == CursorTopPosLimit) {
                 Interlocked.Exchange(ref CurrentCursorTopPos, CursorTopPosLimit - 1);
             }
-            
+
             Console.SetCursorPosition(leftPos, CurrentCursorTopPos);
             Interlocked.Exchange(ref CurrentCursorLeftPos, leftPos);
         }
@@ -38,7 +38,7 @@ namespace ConsoleInteractive {
             if (CurrentCursorTopPos == CursorTopPosLimit) {
                 Interlocked.Exchange(ref CurrentCursorTopPos, CursorTopPosLimit - 1);
             }
-            
+
             Console.SetCursorPosition(CurrentCursorLeftPos, topPos);
             Interlocked.Exchange(ref CurrentCursorTopPos, topPos);
         }
@@ -47,35 +47,42 @@ namespace ConsoleInteractive {
             SetLeftCursorPosition(leftPos);
             SetTopCursorPosition(topPos);
         }
-        
+
+        internal static void ResetCursorPosition() {
+            Console.SetCursorPosition(CurrentCursorLeftPos, CurrentCursorTopPos);
+        }
+
         internal static void SetCursorVisible(bool visible) {
-            
+
             // It's useful to have the cursor visible in debug situations
             #if DEBUG
                 return;
             #endif
-            
+
             Console.CursorVisible = visible;
         }
 
-        internal static void IncrementLeftPos() {
+        internal static void IncrementLeftPos(int amount = 1) {
             if (CursorLeftPosLimit <= CurrentCursorLeftPos + 1)
                 return;
-            CurrentCursorLeftPos = Interlocked.Increment(ref CurrentCursorLeftPos);
+            CurrentCursorLeftPos = Interlocked.Add(ref CurrentCursorLeftPos, amount);
+            if (SuppressInput) return;
             Console.SetCursorPosition(CurrentCursorLeftPos, CurrentCursorTopPos);
         }
-        
-        internal static void DecrementLeftPos() {
+
+        internal static void DecrementLeftPos(int amount = 1) {
             if (CurrentCursorLeftPos == 0)
                 return;
-            CurrentCursorLeftPos = Interlocked.Decrement(ref CurrentCursorLeftPos);
+            CurrentCursorLeftPos = Interlocked.Add(ref CurrentCursorLeftPos, -amount);
+            if (SuppressInput) return;
             Console.SetCursorPosition(CurrentCursorLeftPos, CurrentCursorTopPos);
         }
-        
+
         internal static void IncrementTopPos() {
             if (CursorTopPosLimit <= CurrentCursorTopPos + 1)
                 return;
             CurrentCursorTopPos = Interlocked.Increment(ref CurrentCursorTopPos);
+            if (SuppressInput) return;
             Console.SetCursorPosition(CurrentCursorLeftPos, CurrentCursorTopPos);
         }
     }


### PR DESCRIPTION
* Support simulated pop-up style display of command prompts.
* Modify the keypress event to an input buffer change event. (To make it easier to implement the command prompt feature.)
* Supports deleting an entire word by Ctrl+backspace or Ctrl+delete, as well as using Ctrl+left arrow and Ctrl+right arrow to move in word units.
* Improved algorithm for calculating the number of lines of text, which adds support for characters that occupy two spaces.
* Fix https://github.com/MCCTeam/Minecraft-Console-Client/issues/2336
* There are also some minor bug fixes.

(It's ready to be merged)

![7](https://user-images.githubusercontent.com/26017411/205450213-56ad0bce-8c71-4232-a4c8-e9cb0f908f7b.gif)