### PR TITLE
Add FallbackWriter for Docker environment

### DIFF
--- a/ConsoleInteractive/ConsoleInteractive/ConsoleBuffer.cs
+++ b/ConsoleInteractive/ConsoleInteractive/ConsoleBuffer.cs
@@ -97,7 +97,12 @@ namespace ConsoleInteractive {
         /// <summary>
         /// Console width is actually 0 indexed, so we need to subtract 1 from the width.
         /// </summary>
-        internal static int UserInputBufferMaxLength { get { return Console.BufferWidth - 1 - PrefixTotalLength; } }
+        internal static int UserInputBufferMaxLength {
+            get {
+                int result = Console.BufferWidth - 1 - PrefixTotalLength;
+                return result > 0 ? result : 0;
+            }
+        }
 
         /// <summary>
         /// Stores the contents of the input area at the time of the last call to redraw.


### PR DESCRIPTION
For non-windows platform Console.BufferWidth return 0 and any attempts to change it will lead to System.PlatformNotSupportedException. This commit add simple FallbackWriter wraper around Console.WriteLine

Related issue: #9

### Testing

I have tested it in Portainer as a Stack (i.e. docker-compose.yaml)

```yaml
# https://mccteam.github.io/guide/installation.html#using-docker
version: '3.8'

services:
  minecraft-client:
    image: localhost/minecraft-console-client:latest
    container_name: 'minecraft-client'
    environment:
    - MCC_SKIP_REDOWNLOAD=true
    volumes:
    - data:/opt/data
    - /etc/timezone:/etc/timezone:ro
    - /etc/localtime:/etc/localtime:ro
    stdin_open: true
    tty: true

volumes:
  data:
    external: true
```

### Observation

To avoid 'corrupted' logs like described in https://github.com/breadbyte/ConsoleInteractive/issues/9#issuecomment-1731909558 add `Display_Input = false` to `MinecraftClient.init`